### PR TITLE
Fix growth rate daily calculation

### DIFF
--- a/analyze _covid19.ipynb
+++ b/analyze _covid19.ipynb
@@ -4324,7 +4324,7 @@
     "        data_start = pd.to_datetime(data_start)\n",
     "        \n",
     "    data_end = data.observationdate.max()\n",
-    "    n = (data_end - data_start).days\n",
+    "    n = data.loc[data.observationdate.between(data_start, data_end)].shape[0]-1\n",
     "    rate = list(map(\n",
     "        lambda x: (data[variable].iloc[x] - data[variable].iloc[x-1]) / data[variable].iloc[x-1],\n",
     "        range(1, n+1)\n",


### PR DESCRIPTION
## Summary
- fix calculation of `n` in `growth_rate_daily` for stable indexing

## Testing
- `python3 -m py_compile analysis.py` *(fails: invalid syntax in extracted script)*
- `python3 -m py_compile "analyze _covid19.ipynb"`

------
https://chatgpt.com/codex/tasks/task_e_6881404ff908832899548f6181dc1c1a